### PR TITLE
Rename salt_describe_mode to salt_describe

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,8 @@ To get started with your new project:
     # Build the docs, serve, and view in your web browser:
     python -m nox -e docs && (cd docs/_build/html; python -m webbrowser localhost:8000; python -m http.server; cd -)
 
-    # Run the example function
-    salt-call --local salt-describe.example_function text="Happy Hacking!"
+    # Run the pkg describe function
+    salt-run salt_describe.pkg <minion-tgt>
+
+    # Run the file describe function
+    salt-run salt_describe.file <minion-tgt> <file name>


### PR DESCRIPTION
- Adds instructions to README
- Create top file if it does not exist
- Search for SLS files in targets directory and add it to the generated top file.