### PR TITLE
Fix user creation  when there are no pillar values

### DIFF
--- a/src/saltext/salt_describe/runners/salt_describe_user.py
+++ b/src/saltext/salt_describe/runners/salt_describe_user.py
@@ -73,6 +73,7 @@ def user(tgt, require_groups=False, tgt_type="glob", config_system="salt"):
                 {"shell": user["shell"]},
                 {"groups": user["groups"]},
                 {"password": f'{{{{ salt["pillar.get"]("users:{username}","*") }}}}'},
+                {"enforce_password": True},
                 {"date": shadow["lstchg"]},
                 {"mindays": shadow["min"]},
                 {"maxdays": shadow["max"]},

--- a/tests/unit/runners/test_salt_describe_user_group.py
+++ b/tests/unit/runners/test_salt_describe_user_group.py
@@ -105,6 +105,7 @@ def test_user():
                 {"shell": "/usr/bin/zsh"},
                 {"groups": ["adm"]},
                 {"password": '{{ salt["pillar.get"]("users:testuser","*") }}'},
+                {"enforce_password": True},
                 {"date": 19103},
                 {"mindays": 0},
                 {"maxdays": 99999},


### PR DESCRIPTION
Add enforce_password: False to the user.present state so the password is not set to empty if the user already exists when running the generated states.