### PR TITLE
fixing parse_salt_ret for multiple targets

### DIFF
--- a/src/saltext/salt_describe/utils/init.py
+++ b/src/saltext/salt_describe/utils/init.py
@@ -42,11 +42,13 @@ def parse_salt_ret(ret, tgt):
     Parse the Salt return to check for Success
     or Error
     """
-    ret = ret.get(tgt)
-    if "ERROR:" in ret:
-        log.error(ret)
-        return False
-    elif "is not available" in ret:
-        log.error(ret)
-        return False
-    return True
+    _status = []
+    for _tgt in ret:
+        if "ERROR:" in ret[_tgt]:
+            log.error(ret)
+            _status.append(False)
+        elif "is not available" in ret[_tgt]:
+            log.error(ret)
+            _status.append(False)
+        _status.append(True)
+    return all(_status)

--- a/tests/unit/utils/test_init.py
+++ b/tests/unit/utils/test_init.py
@@ -78,3 +78,48 @@ def test_parse_salt_ret(caplog, ret, exp_ret):
     assert describe_util.parse_salt_ret(ret=ret, tgt=tgt) is exp_ret
     if not exp_ret:
         assert ret[tgt] in caplog.text
+
+
+@pytest.mark.parametrize(
+    "ret,exp_ret",
+    [
+        ("ERROR: firwalld is not running", False),
+        ("Firewalld is not available", False),
+        ("Ran cmd successfully", True),
+    ],
+)
+def test_parse_salt_multiple_ret(caplog, ret, exp_ret):
+    tgt = "*"
+    _ret = {
+        "test_minion1": ("Ran cmd successfully", True),
+        "test_minion2": ("Ran cmd successfully", True),
+        "test_minion3": ret,
+    }
+    tgts = ["test_minion1", "test_minion2", "test_minion3"]
+    assert describe_util.parse_salt_ret(ret=_ret, tgt=tgt) is exp_ret
+    if not exp_ret:
+        for _tgt in tgts:
+            if _ret[_tgt] == ret:
+                assert _ret[_tgt] in caplog.text
+
+    tgt = "*"
+    _ret = {
+        "test_minion1": ("Ran cmd successfully", True),
+        "test_minion2": ret,
+        "test_minion3": ret,
+    }
+    tgts = ["test_minion1", "test_minion2", "test_minion3"]
+    assert describe_util.parse_salt_ret(ret=_ret, tgt=tgt) is exp_ret
+    if not exp_ret:
+        for _tgt in tgts:
+            if _ret[_tgt] == ret:
+                assert _ret[_tgt] in caplog.text
+
+    tgt = "*"
+    _ret = {"test_minion1": ret, "test_minion2": ret, "test_minion3": ret}
+    tgts = ["test_minion1", "test_minion2", "test_minion3"]
+    assert describe_util.parse_salt_ret(ret=_ret, tgt=tgt) is exp_ret
+    if not exp_ret:
+        for _tgt in tgts:
+            if _ret[_tgt] == ret:
+                assert _ret[_tgt] in caplog.text


### PR DESCRIPTION
fixing parse_salt_ret when there are multiple targets in the return d…ata, eg. when a target of * is passed.