### PR TITLE
Fix top.sls when it does not exist

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,8 +20,17 @@ def salt_factories_config():
 
 
 @pytest.fixture(scope="package")
-def master(salt_factories):
-    config_defaults = {"enable_fqdns_grains": False, "timeout": 120}
+def master(salt_factories, base_env_state_tree_root_dir):
+    config_defaults = {
+        "file_roots": {
+            "base": [
+                str(base_env_state_tree_root_dir),
+            ]
+        },
+        "enable_fqdns_grains": False,
+        "timeout": 120,
+    }
+
     return salt_factories.salt_master_daemon(random_string("master-"), defaults=config_defaults)
 
 
@@ -29,3 +38,36 @@ def master(salt_factories):
 def minion(master):
     config_defaults = {"enable_fqdns_grains": False, "timeout": 120}
     return master.salt_minion_daemon(random_string("minion-"), defaults=config_defaults)
+
+
+@pytest.fixture(scope="session")
+def integration_files_dir(salt_factories):
+    """
+    Fixture which returns the salt integration files directory path.
+    Creates the directory if it does not yet exist.
+    """
+    dirname = salt_factories.root_dir / "integration-files"
+    dirname.mkdir(exist_ok=True)
+    return dirname
+
+
+@pytest.fixture(scope="session")
+def state_tree_root_dir(integration_files_dir):
+    """
+    Fixture which returns the salt state tree root directory path.
+    Creates the directory if it does not yet exist.
+    """
+    dirname = integration_files_dir / "state-tree"
+    dirname.mkdir(exist_ok=True)
+    return dirname
+
+
+@pytest.fixture(scope="session")
+def base_env_state_tree_root_dir(state_tree_root_dir):
+    """
+    Fixture which returns the salt base environment state tree directory path.
+    Creates the directory if it does not yet exist.
+    """
+    dirname = state_tree_root_dir / "base"
+    dirname.mkdir(exist_ok=True)
+    return dirname

--- a/tests/integration/runners/test_salt_describe.py
+++ b/tests/integration/runners/test_salt_describe.py
@@ -1,0 +1,44 @@
+# Copyright 2023 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+import yaml
+
+
+def test_top(salt_run_cli, minion, base_env_state_tree_root_dir):
+    """
+    Test describe.top. Multiple scenarios tested:
+        - When top.sls does not exist. Ensure top.sls
+        is generated correctly with data.
+        - When describe.top is called again when no other
+        SLS file has been added
+        - When describe.top is called after another SLS file
+        has been added.
+    """
+    # First create a SLS file with describe
+    ret = salt_run_cli.run("describe.host", tgt=minion.id)
+    assert ret.returncode == 0
+    # Now generate the top data with the SLS data
+    ret = salt_run_cli.run("describe.top", tgt=minion.id)
+    assert ret.returncode == 0
+    gen_sls = ret.data["Generated SLS file locations"]
+    with open(gen_sls) as fp:
+        data = yaml.safe_load(fp)
+    assert data["base"][minion.id] == [f"{minion.id}.host"]
+
+    # Run describe.top and ensure it doesn't add any other entires
+    ret = salt_run_cli.run("describe.top", tgt=minion.id)
+    assert ret.returncode == 0
+    with open(gen_sls) as fp:
+        data = yaml.safe_load(fp)
+    assert data["base"][minion.id] == [f"{minion.id}.host"]
+    assert len(data["base"][minion.id]) == 1
+
+    # Now add another SLS file and then run top again to ensure it adds it
+    ret = salt_run_cli.run("describe.pkg", tgt=minion.id)
+    assert ret.returncode == 0
+    ret = salt_run_cli.run("describe.top", tgt=minion.id)
+    assert ret.returncode == 0
+    with open(gen_sls) as fp:
+        data = yaml.safe_load(fp)
+    assert data["base"][minion.id] == [f"{minion.id}.host", f"{minion.id}.pkg"]
+    assert len(data["base"][minion.id]) == 2


### PR DESCRIPTION
Fixes: https://github.com/saltstack/salt-describe/issues/54

The above issue is run into when a top.sls file does not currently exist.
This PR also resolves the following scenarios:
  - When adding more SLS files and then running describe.top again
  - When running describe.top when no SLS files need to be added, when its already created.