### PR TITLE
Handle additional error cases

### DIFF
--- a/src/saltext/salt_describe/utils/init.py
+++ b/src/saltext/salt_describe/utils/init.py
@@ -43,15 +43,16 @@ def parse_salt_ret(ret, tgt):
     or Error
     """
     _status = []
+    _errorrs = [
+        "ERROR:",
+        "is not available",
+        "module cannot be loaded",
+        "__virtual__ returned False",
+    ]
     for _tgt in ret:
-        if "ERROR:" in ret[_tgt]:
-            log.error(ret)
-            _status.append(False)
-        elif "is not available" in ret[_tgt]:
-            log.error(ret)
-            _status.append(False)
-        elif "module cannot be loaded" in ret[_tgt]:
-            log.error(ret)
-            _status.append(False)
+        for _error in _errorrs:
+            if _error in ret[_tgt]:
+                log.error(ret)
+                _status.append(False)
         _status.append(True)
     return all(_status)

--- a/tests/unit/runners/test_salt_describe_cron.py
+++ b/tests/unit/runners/test_salt_describe_cron.py
@@ -184,4 +184,17 @@ def test_cron(tmp_path):
             )
 
 
+def test_cron_crontab_unavailable(tmp_path):
+    cron_ret = {
+        "minion": "'cron' __virtual__ returned False: Cannot load cron module: crontab command not found"
+    }
+
+    user = "fake_user"
+    with patch.dict(
+        salt_describe_cron_runner.__salt__, {"salt.execute": MagicMock(return_value=cron_ret)}
+    ):
+        with patch.object(salt_describe_cron_runner, "generate_files") as generate_mock:
+            assert not salt_describe_cron_runner.cron("minion", user)
+
+
 # pylint: enable=line-too-long


### PR DESCRIPTION
Handle the situation where a Salt module returns False in the __virtual__ function, eg. cron module when crontab is unavailable.  Consolidate the error checks.