### PR TITLE
Make chef and ansible returns consistent

### DIFF
--- a/src/saltext/salt_describe/utils/ansible_describe.py
+++ b/src/saltext/salt_describe/utils/ansible_describe.py
@@ -24,4 +24,4 @@ def generate_files(opts, minion, state, sls_name="default", env="base", root=Non
     with salt.utils.files.fopen(minion_state_file, "w") as fp_:
         fp_.write(state)
 
-    return True
+    return minion_state_file

--- a/src/saltext/salt_describe/utils/chef_describe.py
+++ b/src/saltext/salt_describe/utils/chef_describe.py
@@ -24,4 +24,4 @@ def generate_files(opts, minion, state, sls_name="default", env="base", root=Non
     with salt.utils.files.fopen(minion_state_file, "w") as fp_:
         fp_.write(state)
 
-    return True
+    return minion_state_file

--- a/tests/unit/utils/test_ansible_describe.py
+++ b/tests/unit/utils/test_ansible_describe.py
@@ -24,12 +24,12 @@ def test_generate_files(tmp_path):
 
     yml = yaml.dump(yml_contents)
     root = tmp_path / "ansible" / "minion"
+    yml_file = root / "file.yml"
     assert (
         ansible_describe_util.generate_files(
             {}, "minion", yml, sls_name="file", env="prod", root=tmp_path
         )
-        is True
+        == yml_file
     )
-    yml_file = root / "file.yml"
     assert yml_file.exists()
     assert yaml.safe_load(yml_file.read_text()) == yml_contents


### PR DESCRIPTION
Return the path to the chef recipe or ansible playback when it has been generated.