### PR TITLE
 Fixing 3006 running user changes

### DIFF
--- a/src/saltext/salt_describe/runners/salt_describe_cron.py
+++ b/src/saltext/salt_describe/runners/salt_describe_cron.py
@@ -176,11 +176,7 @@ def cron(tgt, user="root", include_pre=True, tgt_type="glob", config_system="sal
 
         sls_yaml = yaml.dump(final_sls)
         sls_files.append(
-            str(
-                generate_files(
-                    __opts__, minion, sls_yaml, sls_name="cron", config_system=config_system
-                )
-            )
+            generate_files(__opts__, minion, sls_yaml, sls_name="cron", config_system=config_system)
         )
 
     return ret_info(sls_files, mod=mod_name)

--- a/src/saltext/salt_describe/runners/salt_describe_firewalld.py
+++ b/src/saltext/salt_describe/runners/salt_describe_firewalld.py
@@ -80,10 +80,8 @@ def firewalld(tgt, tgt_type="glob", config_system="salt"):
         state = yaml.dump(state_contents)
 
         sls_files.append(
-            str(
-                generate_files(
-                    __opts__, minion, state, sls_name="firewalld", config_system=config_system
-                )
+            generate_files(
+                __opts__, minion, state, sls_name="firewalld", config_system=config_system
             )
         )
 

--- a/src/saltext/salt_describe/runners/salt_describe_host.py
+++ b/src/saltext/salt_describe/runners/salt_describe_host.py
@@ -63,11 +63,7 @@ def host(tgt, tgt_type="glob", config_system="salt"):
 
         state = yaml.dump(state_contents)
         sls_files.append(
-            str(
-                generate_files(
-                    __opts__, minion, state, sls_name="host", config_system=config_system
-                )
-            )
+            generate_files(__opts__, minion, state, sls_name="host", config_system=config_system)
         )
 
     return ret_info(sls_files, mod=mod_name)

--- a/src/saltext/salt_describe/runners/salt_describe_iptables.py
+++ b/src/saltext/salt_describe/runners/salt_describe_iptables.py
@@ -70,10 +70,8 @@ def iptables(tgt, tgt_type="glob", config_system="salt"):
         state = yaml.dump(state_contents)
 
         sls_files.append(
-            str(
-                generate_files(
-                    __opts__, minion, state, sls_name="iptables", config_system=config_system
-                )
+            generate_files(
+                __opts__, minion, state, sls_name="iptables", config_system=config_system
             )
         )
 

--- a/src/saltext/salt_describe/runners/salt_describe_pip.py
+++ b/src/saltext/salt_describe/runners/salt_describe_pip.py
@@ -93,9 +93,7 @@ def pip(tgt, tgt_type="glob", bin_env=None, config_system="salt", **kwargs):
         state = yaml.dump(state_contents)
 
         sls_files.append(
-            str(
-                generate_files(__opts__, minion, state, sls_name="pip", config_system=config_system)
-            )
+            generate_files(__opts__, minion, state, sls_name="pip", config_system=config_system)
         )
 
     return ret_info(sls_files, mod=mod_name)

--- a/src/saltext/salt_describe/runners/salt_describe_pkg.py
+++ b/src/saltext/salt_describe/runners/salt_describe_pkg.py
@@ -166,10 +166,9 @@ def pkg(
             state = yaml.dump(state_contents)
         else:
             state = "\n".join(state_contents)
+
         sls_files.append(
-            str(
-                generate_files(__opts__, minion, state, sls_name="pkg", config_system=config_system)
-            )
+            generate_files(__opts__, minion, state, sls_name="pkg", config_system=config_system)
         )
 
     return ret_info(sls_files, mod=mod_name)

--- a/src/saltext/salt_describe/runners/salt_describe_pkgrepo.py
+++ b/src/saltext/salt_describe/runners/salt_describe_pkgrepo.py
@@ -115,10 +115,8 @@ def pkgrepo(tgt, tgt_type="glob", config_system="salt"):
         state = yaml.dump(state_contents)
 
         sls_files.append(
-            str(
-                generate_files(
-                    __opts__, minion, state, sls_name=state_name, config_system=config_system
-                )
+            generate_files(
+                __opts__, minion, state, sls_name=state_name, config_system=config_system
             )
         )
 

--- a/src/saltext/salt_describe/runners/salt_describe_service.py
+++ b/src/saltext/salt_describe/runners/salt_describe_service.py
@@ -210,11 +210,7 @@ def service(tgt, tgt_type="glob", config_system="salt", **kwargs):
         else:
             state = "\n".join(state_contents)
         sls_files.append(
-            str(
-                generate_files(
-                    __opts__, minion, state, sls_name="service", config_system=config_system
-                )
-            )
+            generate_files(__opts__, minion, state, sls_name="service", config_system=config_system)
         )
 
     return ret_info(sls_files, mod=mod_name)

--- a/src/saltext/salt_describe/runners/salt_describe_sysctl.py
+++ b/src/saltext/salt_describe/runners/salt_describe_sysctl.py
@@ -59,11 +59,7 @@ def sysctl(tgt, sysctl_items, tgt_type="glob", config_system="salt"):
 
         state = yaml.dump(state_contents)
         sls_files.append(
-            str(
-                generate_files(
-                    __opts__, minion, state, sls_name="sysctl", config_system=config_system
-                )
-            )
+            generate_files(__opts__, minion, state, sls_name="sysctl", config_system=config_system)
         )
 
     return ret_info(sls_files, mod=mod_name)

--- a/src/saltext/salt_describe/runners/salt_describe_timezone.py
+++ b/src/saltext/salt_describe/runners/salt_describe_timezone.py
@@ -56,10 +56,8 @@ def timezone(tgt, tgt_type="glob", config_system="salt"):
         state = yaml.dump(state_contents)
 
         sls_files.append(
-            str(
-                generate_files(
-                    __opts__, minion, state, sls_name="timezone", config_system=config_system
-                )
+            generate_files(
+                __opts__, minion, state, sls_name="timezone", config_system=config_system
             )
         )
 

--- a/src/saltext/salt_describe/runners/salt_describe_user.py
+++ b/src/saltext/salt_describe/runners/salt_describe_user.py
@@ -123,11 +123,7 @@ def user(
         state = yaml.dump(state_contents)
         pillars = yaml.dump(pillars)
         sls_files.append(
-            str(
-                generate_files(
-                    __opts__, minion, state, sls_name="users", config_system=config_system
-                )
-            )
+            generate_files(__opts__, minion, state, sls_name="users", config_system=config_system)
         )
         generate_pillars(__opts__, minion, pillars, sls_name="users")
     return ret_info(sls_files, mod=mod_name)
@@ -175,11 +171,7 @@ def group(
         state = yaml.dump(state_contents)
 
         sls_files.append(
-            str(
-                generate_files(
-                    __opts__, minion, state, sls_name="groups", config_system=config_system
-                )
-            )
+            generate_files(__opts__, minion, state, sls_name="groups", config_system=config_system)
         )
 
     return ret_info(sls_files, mod=mod_name)

--- a/src/saltext/salt_describe/utils/ansible_describe.py
+++ b/src/saltext/salt_describe/utils/ansible_describe.py
@@ -1,12 +1,15 @@
 # Copyright 2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 #
+import logging
 import pathlib
 
 import salt.config
 import salt.syspaths
 import salt.utils.files
 import yaml
+
+log = logging.getLogger(__name__)
 
 
 def generate_files(opts, minion, state, sls_name="default", env="base", root=None):
@@ -17,7 +20,13 @@ def generate_files(opts, minion, state, sls_name="default", env="base", root=Non
         minion_state_root = pathlib.Path("/srv", "ansible", minion)
     else:
         minion_state_root = pathlib.Path(root, "ansible", minion)
-    minion_state_root.mkdir(parents=True, exist_ok=True)
+    try:
+        minion_state_root.mkdir(parents=True, exist_ok=True)
+    except PermissionError:
+        log.warning(
+            f"Unable to create directory {str(minion_state_root)}.  Check that the salt user has the correct permissions."
+        )
+        return False
 
     minion_state_file = minion_state_root / f"{sls_name}.yml"
 

--- a/src/saltext/salt_describe/utils/chef_describe.py
+++ b/src/saltext/salt_describe/utils/chef_describe.py
@@ -1,12 +1,15 @@
 # Copyright 2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 #
+import logging
 import pathlib
 
 import salt.config
 import salt.syspaths
 import salt.utils.files
 import yaml
+
+log = logging.getLogger(__name__)
 
 
 def generate_files(opts, minion, state, sls_name="default", env="base", root=None):
@@ -17,7 +20,13 @@ def generate_files(opts, minion, state, sls_name="default", env="base", root=Non
         minion_state_root = pathlib.Path("/srv", "chef", minion)
     else:
         minion_state_root = pathlib.Path(root, "chef", minion)
-    minion_state_root.mkdir(parents=True, exist_ok=True)
+    try:
+        minion_state_root.mkdir(parents=True, exist_ok=True)
+    except PermissionError:
+        log.warning(
+            f"Unable to create directory {str(minion_state_root)}.  Check that the salt user has the correct permissions."
+        )
+        return False
 
     minion_state_file = minion_state_root / f"{sls_name}.rb"
 

--- a/src/saltext/salt_describe/utils/init.py
+++ b/src/saltext/salt_describe/utils/init.py
@@ -17,7 +17,11 @@ def generate_files(opts, minion, state, sls_name="default", env="base", config_s
     """
     config = getattr(saltext.salt_describe.utils, f"{config_system}_describe")
 
-    return config.generate_files(opts, minion, state, sls_name=sls_name, env=env)
+    res = config.generate_files(opts, minion, state, sls_name=sls_name, env=env)
+    if res:
+        return str(res)
+    else:
+        return res
 
 
 def get_minion_state_file_root(opts, minion, env="base", config_system="salt"):
@@ -30,7 +34,7 @@ def get_minion_state_file_root(opts, minion, env="base", config_system="salt"):
 
 
 def ret_info(sls_files, mod=None):
-    if not sls_files:
+    if not any(sls_files):
         if mod:
             log.error("Could not generate SLS file for %s", mod)
         return False

--- a/src/saltext/salt_describe/utils/salt_describe.py
+++ b/src/saltext/salt_describe/utils/salt_describe.py
@@ -1,12 +1,15 @@
 # Copyright 2023 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 #
+import logging
 import pathlib
 
 import salt.config
 import salt.syspaths
 import salt.utils.files
 import yaml
+
+log = logging.getLogger(__name__)
 
 
 def get_state_file_root(opts, env="base"):
@@ -42,7 +45,13 @@ def generate_files(opts, minion, state, sls_name="default", env="base"):
     Generate an sls file for the minion with given state contents
     """
     minion_state_root = get_minion_state_file_root(opts, minion, env=env)
-    minion_state_root.mkdir(parents=True, exist_ok=True)
+    try:
+        minion_state_root.mkdir(parents=True, exist_ok=True)
+    except PermissionError:
+        log.warning(
+            f"Unable to create directory {str(minion_state_root)}.  Check that the salt user has the correct permissions."
+        )
+        return False
 
     minion_state_file = minion_state_root / f"{sls_name}.sls"
 
@@ -58,7 +67,13 @@ def generate_init(opts, minion=None, env="base"):
     Generate the init.sls for the minion or minions
     """
     minion_state_root = get_minion_state_file_root(opts, minion, env=env)
-    minion_state_root.mkdir(parents=True, exist_ok=True)
+    try:
+        minion_state_root.mkdir(parents=True, exist_ok=True)
+    except PermissionError:
+        log.warning(
+            f"Unable to create directory {str(minion_state_root)}.  Check that the salt user has the correct permissions."
+        )
+        return False
 
     minion_init_file = minion_state_root / "init.sls"
 
@@ -81,7 +96,13 @@ def generate_pillar_init(opts, minion=None, env="base"):
     Generate the init.sls for the minion or minions
     """
     minion_pillar_root = get_minion_pillar_file_root(opts, minion, env=env)
-    minion_pillar_root.mkdir(parents=True, exist_ok=True)
+    try:
+        minion_pillar_root.mkdir(parents=True, exist_ok=True)
+    except PermissionError:
+        log.warning(
+            f"Unable to create directory {str(minion_pillar_root)}.  Check that the salt user has the correct permissions."
+        )
+        return False
 
     minion_init_file = minion_pillar_root / "init.sls"
 
@@ -104,7 +125,13 @@ def generate_pillars(opts, minion, pillar, sls_name="default", env="base"):
     Generate pillar files for the minion to hold more sensitive information
     """
     minion_pillar_root = get_minion_pillar_file_root(opts, minion, env=env)
-    minion_pillar_root.mkdir(parents=True, exist_ok=True)
+    try:
+        minion_pillar_root.mkdir(parents=True, exist_ok=True)
+    except PermissionError:
+        log.warning(
+            f"Unable to create directory {str(minion_pillar_root)}.  Check that the salt user has the correct permissions."
+        )
+        return False
 
     minion_pillar_file = minion_pillar_root / f"{sls_name}.sls"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@
 import os
 
 import pytest
+import salt.config
 from saltext.salt_describe import PACKAGE_ROOT
 from saltfactories.utils import random_string
 
@@ -71,3 +72,37 @@ def base_env_state_tree_root_dir(state_tree_root_dir):
     dirname = state_tree_root_dir / "base"
     dirname.mkdir(exist_ok=True)
     return dirname
+
+
+@pytest.fixture
+def minion_opts(tmp_path):
+    """
+    Default minion configuration with relative temporary paths to not require root permissions.
+    """
+    root_dir = tmp_path / "minion"
+    opts = salt.config.DEFAULT_MINION_OPTS.copy()
+    opts["__role"] = "minion"
+    opts["root_dir"] = str(root_dir)
+    for name in ("cachedir", "pki_dir", "sock_dir", "conf_dir"):
+        dirpath = root_dir / name
+        dirpath.mkdir(parents=True)
+        opts[name] = str(dirpath)
+    opts["log_file"] = "logs/minion.log"
+    return opts
+
+
+@pytest.fixture
+def master_opts(tmp_path):
+    """
+    Default master configuration with relative temporary paths to not require root permissions.
+    """
+    root_dir = tmp_path / "master"
+    opts = salt.config.DEFAULT_MASTER_OPTS.copy()
+    opts["__role"] = "master"
+    opts["root_dir"] = str(root_dir)
+    for name in ("cachedir", "pki_dir", "sock_dir", "conf_dir"):
+        dirpath = root_dir / name
+        dirpath.mkdir(parents=True)
+        opts[name] = str(dirpath)
+    opts["log_file"] = "logs/master.log"
+    return opts

--- a/tests/unit/runners/test_salt_describe_pkg.py
+++ b/tests/unit/runners/test_salt_describe_pkg.py
@@ -2,11 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 import logging
+from pathlib import PosixPath
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
 import saltext.salt_describe.runners.salt_describe_pkg as salt_describe_pkg_runner
+import saltext.salt_describe.utils.salt_describe as salt_describe_util
 import yaml
 
 log = logging.getLogger(__name__)
@@ -22,7 +24,7 @@ def configure_loader_modules():
     }
 
 
-def test_pkg():
+def test_pkg(minion_opts):
     pkg_list = {
         "minion": {
             "pkg1": "0.1.2-3",
@@ -48,6 +50,30 @@ def test_pkg():
             generate_mock.assert_called_with(
                 {}, "minion", pkg_sls, sls_name="pkg", config_system="salt"
             )
+
+
+def test_pkg_permission_denied(minion_opts, caplog):
+    pkg_list = {
+        "minion": {
+            "pkg1": "0.1.2-3",
+            "pkg2": "1.2rc5-3",
+            "pkg3": "2.3.4-5",
+            "pk4": "3.4-5",
+            "pkg5": "4.5.6-7",
+        }
+    }
+    with patch.dict(
+        salt_describe_pkg_runner.__salt__, {"salt.execute": MagicMock(return_value=pkg_list)}
+    ):
+        with patch.dict(salt_describe_pkg_runner.__opts__, minion_opts):
+            with patch.object(PosixPath, "mkdir", side_effect=PermissionError) as mock_mkdir:
+                with caplog.at_level(logging.WARNING):
+                    ret = salt_describe_pkg_runner.pkg("minion")
+                    assert not ret
+                    assert (
+                        "Unable to create directory /srv/salt/minion.  "
+                        "Check that the salt user has the correct permissions."
+                    ) in caplog.text
 
 
 def test_pkg_ansible():
@@ -171,3 +197,59 @@ end
             generate_mock.assert_called_with(
                 {}, "minion", pkg_rb_contents, sls_name="pkg", config_system="chef"
             )
+
+
+def test_pkg_ansible_permission_denied(minion_opts, caplog):
+    pkg_list = {
+        "minion": {
+            "pkg1": "0.1.2-3",
+            "pkg2": "1.2rc5-3",
+            "pkg3": "2.3.4-5",
+            "pk4": "3.4-5",
+            "pkg5": "4.5.6-7",
+        }
+    }
+    grains = {"os_family": "Debian"}
+    with patch.dict(
+        salt_describe_pkg_runner.__salt__, {"salt.execute": MagicMock(return_value=pkg_list)}
+    ):
+        with patch.dict(salt_describe_pkg_runner.__opts__, minion_opts), patch(
+            "salt.utils.minions.get_minion_data",
+            MagicMock(return_value=(None, grains, None)),
+        ):
+            with patch.object(PosixPath, "mkdir", side_effect=PermissionError) as mock_mkdir:
+                with caplog.at_level(logging.WARNING):
+                    ret = salt_describe_pkg_runner.pkg("minion", config_system="ansible")
+                    assert not ret
+                    assert (
+                        "Unable to create directory /srv/ansible/minion.  "
+                        "Check that the salt user has the correct permissions."
+                    ) in caplog.text
+
+
+def test_pkg_chef_permission_denied(minion_opts, caplog):
+    pkg_list = {
+        "minion": {
+            "pkg1": "0.1.2-3",
+            "pkg2": "1.2rc5-3",
+            "pkg3": "2.3.4-5",
+            "pk4": "3.4-5",
+            "pkg5": "4.5.6-7",
+        }
+    }
+    grains = {"os_family": "Debian"}
+    with patch.dict(
+        salt_describe_pkg_runner.__salt__, {"salt.execute": MagicMock(return_value=pkg_list)}
+    ):
+        with patch.dict(salt_describe_pkg_runner.__opts__, minion_opts), patch(
+            "salt.utils.minions.get_minion_data",
+            MagicMock(return_value=(None, grains, None)),
+        ):
+            with patch.object(PosixPath, "mkdir", side_effect=PermissionError) as mock_mkdir:
+                with caplog.at_level(logging.WARNING):
+                    ret = salt_describe_pkg_runner.pkg("minion", config_system="chef")
+                    assert not ret
+                    assert (
+                        "Unable to create directory /srv/chef/minion.  "
+                        "Check that the salt user has the correct permissions."
+                    ) in caplog.text


### PR DESCRIPTION
Handle the changes in 3006 where salt-master is no longer running as root and the runner is no longer able to create the state and pillar directories automatically.